### PR TITLE
Fail if any of hg commands fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - pip install pytest-cov
   - pip install pytest-mock
   - pip install requests
-  - pip install prospector
+  - pip install prospector==1.2.0
   - pip install codecov
   - pip install -r requirements.txt
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
   - "%PYTHON%\\python.exe -m pip install pytest"
   - "%PYTHON%\\python.exe -m pip install pytest-cov"
   - "%PYTHON%\\python.exe -m pip install pytest-mock"
-  - "%PYTHON%\\python.exe -m pip install prospector"
+  - "%PYTHON%\\python.exe -m pip install prospector==1.2.0"
   - "%PYTHON%\\python.exe -m pip install codecov"
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
 

--- a/hg-phabdiff/__init__.py
+++ b/hg-phabdiff/__init__.py
@@ -3,19 +3,25 @@
 from mercurial import extensions
 from mercurial import commands
 from plugin import apply_phab_diff
+from logger import log
 
 
 def _update_with_diff(orig, ui, repo, *args, **kwargs):  # pragma: no cover
-    ret = orig(ui, repo, *args, **kwargs)
+    orig_failed = orig(ui, repo, *args, **kwargs)
+    if orig_failed:
+        return orig_failed
     repo_root = repo.url()
     if repo_root.startswith("file:"):
         repo_root = repo_root[5:]
     else:
         raise RuntimeError(
             "could not figure out repo location from '%s'" % repo_root)
-    apply_phab_diff(repo_root)
-    return ret
-
+    try:
+        apply_phab_diff(repo_root)
+    except Exception as e:
+        log(e, ui)
+        return True
+    return False
 
 def uisetup(_):  # pragma: no cover
     extensions.wrapcommand(commands.table, "update", _update_with_diff)

--- a/hg-phabdiff/plugin_test.py
+++ b/hg-phabdiff/plugin_test.py
@@ -24,6 +24,20 @@ class PhabricatorMock(object):
         self.differential = self.DifferentialMock(diff=diff)
 
 
+class Hg(object):
+    def __init__(self, repo_cwd):
+        self.repo_cwd = repo_cwd
+    def check_call(self, *args):
+        return subprocess.check_call([EXE_HG(), "--cwd", self.repo_cwd] + list(args))
+    def check_output(self, *args):
+        return subprocess.check_output([EXE_HG(), "--cwd", self.repo_cwd] + list(args))
+
+    def current_commit(self):
+        return self.check_output('log', '-T', '{node}', '-r', '.')
+    def count_commits(self):
+        return len(self.check_output('log', '-T', 'x'))
+
+
 def test_apply_phab_diff(mocker, prepare_repos):
     (local, patched, patch) = prepare_repos
 
@@ -32,11 +46,13 @@ def test_apply_phab_diff(mocker, prepare_repos):
 
     mocker.patch('plugin.phabricator_factory', side_effect=phabricatormock_factory)
     os.environ[ENVVAR_PHAB_DIFF()] = "test"
+    hg = Hg(local)
+
     plugin.apply_phab_diff(local)
-    subprocess.check_call([EXE_HG(), "out", "--cwd", local, patched])
-    subprocess.check_call([EXE_HG(), "strip", "--cwd", local, "-r", "head()", "--config", "extensions.strip="])
+    hg.check_call("out", patched)
+    hg.check_call("strip", "-r", "head()", "--config", "extensions.strip=")
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
-        subprocess.check_call([EXE_HG(), "out", "--cwd", local, patched])
+        hg.check_call("out", patched)
     assert excinfo.value.returncode == 1
 
 def test_apply_no_diff(prepare_repos):
@@ -44,3 +60,20 @@ def test_apply_no_diff(prepare_repos):
     if ENVVAR_PHAB_DIFF() in os.environ:
         os.environ.pop(ENVVAR_PHAB_DIFF())
     plugin.apply_phab_diff(local)
+
+def test_hg_import_fail(mocker, prepare_repos):
+    (local, _, _) = prepare_repos
+
+    def phabricatormock_factory():
+        return PhabricatorMock(diff="not a diff content")
+
+    mocker.patch('plugin.phabricator_factory', side_effect=phabricatormock_factory)
+    os.environ[ENVVAR_PHAB_DIFF()] = "test"
+    hg = Hg(local)
+
+    commit_before = hg.current_commit()
+    count_before = hg.count_commits()
+    with pytest.raises(RuntimeError, match='hg import failed.+stdin: no diffs found'):
+        plugin.apply_phab_diff(local)
+    assert hg.current_commit() == commit_before
+    assert hg.count_commits() == count_before


### PR DESCRIPTION
- fail the wrapper immediately if the original command failed (e.g. to prevent applying patch on current working copy after "unknown commit id" error)
- fail `apply_phab_diff` if `hg import` fails, to prevent "successfull" `hg update` calls with only a part of the diff applied